### PR TITLE
App-side workaround for CF gorouter bug

### DIFF
--- a/server.js
+++ b/server.js
@@ -55,8 +55,13 @@ http.createServer(function(request, response) {
                 response.end();
                 return;
             }
-
-            response.writeHead(200);
+            if (uri.match(/css$/)) {
+                response.writeHead(200, {
+                    "Content-Type": "text/css"
+                });
+            } else {
+                response.writeHead(200);
+            }
             response.write(file, "binary");
             response.end();
         });


### PR DESCRIPTION
https://github.com/cloudfoundry/gorouter/issues/62

I've hit this with a few node.js apps. The CSS is served as text/plain when deployed to CF systems using the gorouter. This change makes the app work properly on Stackato 3.6.1 and vanilla CF.

I'll leave it up to @btat whether this is worth merging. Don't know when the gorouter bug might be fixed.
